### PR TITLE
Feat/set mint allowance fro admin

### DIFF
--- a/src/Token.sol
+++ b/src/Token.sol
@@ -148,6 +148,28 @@ contract Token is
         _setMintAllowance(account, amount);
     }
 
+    function setMintAllowanceForAdmin(
+      address from,
+      address account,
+      uint256 amount,
+      bytes memory signature
+    ) public onlySystemAccounts {
+      require(
+          from.isValidSignatureNow(
+              0xb77c35c892a1b24b10a2ce49b424e578472333ee8d2456234fff90626332c50f, //change this hash to chosen static message hash
+              signature
+          ),
+          "signature/hash does not match"
+      );
+
+      require(
+          isAdminAccount(from),
+          "Token: from is not a admin account"
+      );
+
+      _setMintAllowance(account, amount);
+    }
+
     // EIP-2612 helper
     function getPermitDigest(
         address owner,

--- a/src/Token.sol
+++ b/src/Token.sol
@@ -148,6 +148,24 @@ contract Token is
         _setMintAllowance(account, amount);
     }
 
+    /**
+     * @notice Allows a system account to set the mint allowance for an admin account, using an admin's signature for authorization.
+     * 
+     * The message expected to be signed by the admin is currently hardcoded with a static hash 
+     * (`0xb77c35c892a1b24b10a2ce49b424e578472333ee8d2456234fff90626332c50f`). This choice could be updated in future 
+     * implementations to allow for dynamic messages, depending on design requirements.
+     * 
+     * Requirements:
+     * - `from` must provide a valid signature matching the hardcoded hash to confirm authorization.
+     * - `from` must be a recognized admin account.
+     * - The function can only be called by accounts designated as system accounts.
+     * 
+     * @param from The address of the admin providing authorization for setting the mint allowance.
+     * @param account The address of the account for which the mint allowance is to be set.
+     * @param amount The new mint allowance to be assigned to the specified account.
+     * @param signature The signature of the admin (`from`), authorizing this allowance adjustment.
+    */
+
     function setMintAllowanceForAdmin(
       address from,
       address account,


### PR DESCRIPTION
### Summary
This PR introduces the `setMintAllowanceForAdmin` function, allowing a system account to set the mint allowance for an admin account using a signature provided by an admin. This function is the sole change in this PR, along with corresponding tests to ensure 100% coverage.

This function's end goal is to allow the admin to authorize actions by simply signing a message rather than submitting a full transaction. This approach ensures that the system account is the sole payer for these transactions, centralizing fee management to a single account.

### Details
- **Functionality**: 
  - The `setMintAllowanceForAdmin` function enables a system account to raise the mint allowance on behalf of an admin, validated by a signature from the admin account.
  - The message to be signed by the admin is currently a static hash, allowing the function to confirm authorization based on this hardcoded message.
  - Only system accounts are permitted to call this function, and the admin providing the signature must be a recognized admin account.

- **Tests**:
  - 100% test coverage is provided for the `setMintAllowanceForAdmin` function.
  - Tests validate correct behaviour with valid signatures, rejection of invalid signatures and admin signatures are accepted.

### Impact
This change is isolated to the `setMintAllowanceForAdmin` function and does not add additional dependencies or modify other functions.

### Future Considerations
Depending on future design decisions, the hardcoded message may be replaced with a dynamic message to allow more flexibility in message signing.
