### PR TITLE
New Validator contract and wire V1 block for Balancer V3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-verify": "^1.0.0",
+    "@openzeppelin/contracts": "^4.9.3",
     "@openzeppelin/contracts-upgradeable": "^4.9.3",
     "@typechain/ethers-v6": "^0.4.0",
     "@typechain/hardhat": "^8.0.0",
@@ -52,5 +53,6 @@
     "typechain": "^8.2.0",
     "typescript": "^5.4.3",
     "web3": "^4.7.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/Validator.sol
+++ b/src/Validator.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import "./IValidator.sol";
 
 /**
@@ -53,13 +54,50 @@ contract Validator is AccessControl, IValidator {
         uint256 /* amount */
     ) external view override returns (bool valid) {
         if (isV1Frontend(msg.sender)) {
-            valid = !(isV1Blocked(from) || isV1Blocked(to));
-            if (!valid) {
-                return false;
+            if (isV1Blocked(from)) {
+                revert(
+                    string(
+                        abi.encodePacked(
+                            "Transfer not supported:",
+                            Strings.toHexString(from),
+                            " is blocked in V1. Please use V2 instead. See https://monerium.dev/docs/tokens"
+                        )
+                    )
+                );
+            }
+            if (isV1Blocked(to)) {
+                revert(
+                    string(
+                        abi.encodePacked(
+                            "Transfer not supported:",
+                            Strings.toHexString(to),
+                            " is blocked in V1. Please use V2 instead. See https://monerium.dev/docs/tokens"
+                        )
+                    )
+                );
             }
         }
-        if (isBlacklisted(from) || isBlacklisted(to)) {
-            return false;
+        if (isBlacklisted(from)) {
+            revert(
+                string(
+                    abi.encodePacked(
+                        "Transfer not supported:",
+                        Strings.toHexString(from),
+                        " is blacklisted."
+                    )
+                )
+            );
+        }
+        if (isBlacklisted(to)) {
+            revert(
+                string(
+                    abi.encodePacked(
+                        "Transfer not supported:",
+                        Strings.toHexString(to),
+                        " is blacklisted."
+                    )
+                )
+            );
         }
         return true;
     }

--- a/src/Validator.sol
+++ b/src/Validator.sol
@@ -51,10 +51,11 @@ contract Validator is AccessControl, IValidator {
     function validate(
         address from,
         address to,
-        uint256 /* amount */
-    ) external view override returns (bool valid) {
+        uint256 amount
+    ) external override returns (bool valid) {
         if (isV1Frontend(msg.sender)) {
             if (isV1Blocked(from)) {
+                emit Decision(from, to, amount, false);
                 revert(
                     string(
                         abi.encodePacked(
@@ -66,6 +67,7 @@ contract Validator is AccessControl, IValidator {
                 );
             }
             if (isV1Blocked(to)) {
+                emit Decision(from, to, amount, false);
                 revert(
                     string(
                         abi.encodePacked(
@@ -78,6 +80,7 @@ contract Validator is AccessControl, IValidator {
             }
         }
         if (isBlacklisted(from)) {
+            emit Decision(from, to, amount, false);
             revert(
                 string(
                     abi.encodePacked(
@@ -89,6 +92,7 @@ contract Validator is AccessControl, IValidator {
             );
         }
         if (isBlacklisted(to)) {
+            emit Decision(from, to, amount, false);
             revert(
                 string(
                     abi.encodePacked(

--- a/src/Validator.sol
+++ b/src/Validator.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import "./IValidator.sol";
+
+/**
+ * @title Validator
+ * @dev Role-based access control for transfer validation and account management.
+ *      Uses OpenZeppelin AccessControl for secure role management.
+ *      docs: https://docs.openzeppelin.com/contracts/4.x/api/access#AccessControl
+ *      audit: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/audits/2023-05-v4.9.pdf
+ */
+contract Validator is AccessControl, IValidator {
+    // Role identifiers
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    bytes32 public constant V1_BLOCKED_ROLE = keccak256("V1_BLOCKED_ROLE");
+    bytes32 public constant BLACKLISTED_ROLE = keccak256("BLACKLISTED_ROLE");
+    bytes32 public constant V1_FRONTEND_ROLE = keccak256("V1_FRONTEND_ROLE");
+
+    // Contract identifier for interface compliance
+    bytes32 private constant ID =
+        0x5341d189213c4172d0c7256f80bc5f8e6350af3aaff7a029625d8dd94f0f82a5;
+
+    /**
+     * @dev Returns the contract identifier.
+     */
+    function CONTRACT_ID() public pure returns (bytes32) {
+        return ID;
+    }
+
+    /**
+     * @dev Sets up initial admin and role relationships.
+     *      The deployer is the default admin.
+     *      ADMIN_ROLE is the admin for blocked, blacklisted, and frontend roles.
+     */
+    constructor() {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _setRoleAdmin(V1_BLOCKED_ROLE, ADMIN_ROLE);
+        _setRoleAdmin(BLACKLISTED_ROLE, ADMIN_ROLE);
+        _setRoleAdmin(V1_FRONTEND_ROLE, ADMIN_ROLE);
+    }
+
+    /**
+     * @dev Validates a transfer between two accounts.
+     *      - If called by a V1 frontend, checks if either account is blocked.
+     *      - Always checks if either account is blacklisted.
+     * @return valid True if transfer is allowed, false otherwise.
+     */
+    function validate(
+        address from,
+        address to,
+        uint256 /* amount */
+    ) external view override returns (bool valid) {
+        if (isV1Frontend(msg.sender)) {
+            valid = !(isV1Blocked(from) || isV1Blocked(to));
+            if (!valid) {
+                return false;
+            }
+        }
+        if (isBlacklisted(from) || isBlacklisted(to)) {
+            return false;
+        }
+        return true;
+    }
+
+    // --- Admin role management ---
+
+    /**
+     * @dev Grants ADMIN_ROLE to an account. Only callable by an admin.
+     */
+    function setAdmin(address account) external {
+        grantRole(ADMIN_ROLE, account);
+    }
+
+    /**
+     * @dev Revokes ADMIN_ROLE from an account. Only callable by an admin.
+     */
+    function revokeAdmin(address account) external {
+        revokeRole(ADMIN_ROLE, account);
+    }
+
+    /**
+     * @dev Checks if an account has ADMIN_ROLE.
+     */
+    function isAdminAccount(address account) public view returns (bool) {
+        return hasRole(ADMIN_ROLE, account);
+    }
+
+    // --- Blocked role management ---
+
+    /**
+     * @dev Grants V1_BLOCKED_ROLE to an account. Only callable by an admin.
+     */
+    function setV1Blocked(address account) external {
+        grantRole(V1_BLOCKED_ROLE, account);
+    }
+
+    /**
+     * @dev Revokes V1_BLOCKED_ROLE from an account. Only callable by an admin.
+     */
+    function revokeV1Blocked(address account) external {
+        revokeRole(V1_BLOCKED_ROLE, account);
+    }
+
+    /**
+     * @dev Checks if an account has V1_BLOCKED_ROLE.
+     */
+    function isV1Blocked(address account) public view returns (bool) {
+        return hasRole(V1_BLOCKED_ROLE, account);
+    }
+
+    // --- Blacklisted role management ---
+
+    /**
+     * @dev Grants BLACKLISTED_ROLE to an account. Only callable by an admin.
+     */
+    function setBlacklisted(address account) external {
+        grantRole(BLACKLISTED_ROLE, account);
+    }
+
+    /**
+     * @dev Revokes BLACKLISTED_ROLE from an account. Only callable by an admin.
+     */
+    function revokeBlacklisted(address account) external {
+        revokeRole(BLACKLISTED_ROLE, account);
+    }
+
+    /**
+     * @dev Checks if an account has BLACKLISTED_ROLE.
+     */
+    function isBlacklisted(address account) public view returns (bool) {
+        return hasRole(BLACKLISTED_ROLE, account);
+    }
+
+    // --- Frontend role management ---
+
+    /**
+     * @dev Grants V1_FRONTEND_ROLE to an account. Only callable by an admin.
+     */
+    function setV1Frontend(address account) external {
+        grantRole(V1_FRONTEND_ROLE, account);
+    }
+
+    /**
+     * @dev Revokes V1_FRONTEND_ROLE from an account. Only callable by an admin.
+     */
+    function revokeV1Frontend(address account) external {
+        revokeRole(V1_FRONTEND_ROLE, account);
+    }
+
+    /**
+     * @dev Checks if an account has V1_FRONTEND_ROLE.
+     */
+    function isV1Frontend(address account) public view returns (bool) {
+        return hasRole(V1_FRONTEND_ROLE, account);
+    }
+}

--- a/test/Validator.t.sol
+++ b/test/Validator.t.sol
@@ -66,15 +66,21 @@ contract ValidatorTest is Test {
 
         // Blocked by frontend
         vm.prank(frontend);
-        assertFalse(validator.validate(blocked, admin, 100));
-        vm.prank(frontend);
-        assertFalse(validator.validate(admin, blocked, 100));
+        vm.expectRevert("Transfer not supported:0x0000000000000000000000000000000000000004 is blocked in V1. Please use V2 instead. See https://monerium.dev/docs/tokens");
+        validator.validate(blocked, admin, 100);
 
-        // Blacklisted always fails
+        vm.prank(frontend);
+        vm.expectRevert("Transfer not supported:0x0000000000000000000000000000000000000004 is blocked in V1. Please use V2 instead. See https://monerium.dev/docs/tokens");
+        validator.validate(admin, blocked, 100);
+
+        // Blacklisted always reverts
         vm.prank(user);
-        assertFalse(validator.validate(blacklisted, admin, 100));
+        vm.expectRevert("Transfer not supported:0x0000000000000000000000000000000000000005 is blacklisted.");
+        validator.validate(blacklisted, admin, 100);
+
         vm.prank(user);
-        assertFalse(validator.validate(admin, blacklisted, 100));
+        vm.expectRevert("Transfer not supported:0x0000000000000000000000000000000000000005 is blacklisted.");
+        validator.validate(admin, blacklisted, 100);
     }
 
     function testContractId() public {

--- a/test/Validator.t.sol
+++ b/test/Validator.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/Validator.sol";
+
+contract ValidatorTest is Test {
+    Validator validator;
+    address owner = address(0x1);
+    address admin = address(0x2);
+    address user = address(0x3);
+    address blocked = address(0x4);
+    address blacklisted = address(0x5);
+    address frontend = address(0x6);
+
+    function setUp() public {
+        vm.prank(owner);
+        validator = new Validator();
+
+        // Grant roles for testing
+        vm.prank(owner);
+        validator.setAdmin(admin);
+
+        vm.prank(admin);
+        validator.setV1Blocked(blocked);
+
+        vm.prank(admin);
+        validator.setBlacklisted(blacklisted);
+
+        vm.prank(admin);
+        validator.setV1Frontend(frontend);
+    }
+
+    function testAdminRole() public {
+        assertTrue(validator.isAdminAccount(admin));
+        vm.prank(owner);
+        validator.revokeAdmin(admin);
+        assertFalse(validator.isAdminAccount(admin));
+    }
+
+    function testBlockedRole() public {
+        assertTrue(validator.isV1Blocked(blocked));
+        vm.prank(admin);
+        validator.revokeV1Blocked(blocked);
+        assertFalse(validator.isV1Blocked(blocked));
+    }
+
+    function testBlacklistedRole() public {
+        assertTrue(validator.isBlacklisted(blacklisted));
+        vm.prank(admin);
+        validator.revokeBlacklisted(blacklisted);
+        assertFalse(validator.isBlacklisted(blacklisted));
+    }
+
+    function testFrontendRole() public {
+        assertTrue(validator.isV1Frontend(frontend));
+        vm.prank(admin);
+        validator.revokeV1Frontend(frontend);
+        assertFalse(validator.isV1Frontend(frontend));
+    }
+
+    function testValidateTransfer() public {
+        // Not blocked or blacklisted
+        vm.prank(user);
+        assertTrue(validator.validate(user, admin, 100));
+
+        // Blocked by frontend
+        vm.prank(frontend);
+        assertFalse(validator.validate(blocked, admin, 100));
+        vm.prank(frontend);
+        assertFalse(validator.validate(admin, blocked, 100));
+
+        // Blacklisted always fails
+        vm.prank(user);
+        assertFalse(validator.validate(blacklisted, admin, 100));
+        vm.prank(user);
+        assertFalse(validator.validate(admin, blacklisted, 100));
+    }
+
+    function testContractId() public {
+        bytes32 expected = 0x5341d189213c4172d0c7256f80bc5f8e6350af3aaff7a029625d8dd94f0f82a5;
+        assertEq(validator.CONTRACT_ID(), expected);
+    }
+
+    function testIsAdminAccount() public {
+        assertFalse(validator.isAdminAccount(owner));
+        assertTrue(validator.isAdminAccount(admin));
+        assertFalse(validator.isAdminAccount(address(0xdead)));
+    }
+    function testIsV1Blocked() public {
+        assertTrue(validator.isV1Blocked(blocked));
+        assertFalse(validator.isV1Blocked(address(0xdead)));
+    }
+    function testIsBlacklisted() public {
+        assertTrue(validator.isBlacklisted(blacklisted));
+        assertFalse(validator.isBlacklisted(address(0xdead)));
+    }
+    function testIsV1Frontend() public {
+        assertTrue(validator.isV1Frontend(frontend));
+        assertFalse(validator.isV1Frontend(address(0xdead)));
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -686,6 +686,11 @@
   resolved "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz"
   integrity sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==
 
+"@openzeppelin/contracts@^4.9.3":
+  version "4.9.6"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.6.tgz#2a880a24eb19b4f8b25adc2a5095f2aa27f39677"
+  integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
+
 "@openzeppelin/defender-admin-client@^1.52.0":
   version "1.54.6"
   resolved "https://registry.npmjs.org/@openzeppelin/defender-admin-client/-/defender-admin-client-1.54.6.tgz"


### PR DESCRIPTION
# New `Validator` contract and wire V1 block for Balancer V3

## Scope

* Context, Balancer V3 issue:

  > Balancer V3 uses a cash till pattern. Operations settle at the end of the transaction. With double entrypoint tokens that share state, like EUReV1 and EUReV2, you can pay once and get credit twice. If two pools exist, one can be drained.
  > We can block the EURe V1 frontend from touching Balancer V3 by upgrading the Validator used by EURe V2. Balancer V3 settles via [a single Vault address](https://gnosisscan.io/address/0xbA1333333333a1BA1108E8412f11850A5C319bA9#tokentxns), so blocking that address prevents all new V3 pools from using V1.
  > EURe V1 is not upgradeable, but every EURe V1 state change goes through EURe  V2’s `*_withCaller` entrypoints, so EURe V2 can refuse Balancer-related calls. Block both `transfer` and `transferFrom` to the V3 Vault.
<p align="center" style="margin: 30px 0;">
    <img src="https://github.com/user-attachments/assets/b0433835-1ecf-4e95-87c7-d955134f798d" alt="V1 Frontend using V2 Proxy as controller" style="max-width: 500px;" /><br />
    <em>Figure: V1 Frontend using V2 Proxy as controller</em>
</p>

* Add `src/Validator.sol` that V2 calls before state changes.
* Roles:

  * `ADMIN_ROLE` manages other roles.
  * `V1_FRONTEND_ROLE` marks the chain’s V1 frontend.
  * `V1_BLOCKED_ROLE` marks counterparties V1 must not touch, for example the Balancer V3 Vault.
  * `BLACKLISTED_ROLE` blocks addresses globally.
* Tests in `test/Validator.t.sol`. We have 100% coverage for `Validator`.

## Implementation

* `Validator` is a pure view gate: `validate(from, to, amount) -> bool`.

https://github.com/monerium/smart-contracts/blob/31f03202681c80b92d99164483361ff1c69af079/src/Validator.sol#L45-L103

  * For V1 transfers, the front end will always be the `msg.sender`. Because it's using the`*_withCaller` entrypoints in V2.
  * If `msg.sender` has `V1_FRONTEND_ROLE`, return false when `from` or `to` has `V1_BLOCKED_ROLE`.
  * Always return false when `from` or `to` has `BLACKLISTED_ROLE`.
* `DEFAULT_ADMIN_ROLE` granted to deployer. `ADMIN_ROLE` is admin for all other roles.
* Helpers: `isAdminAccount`, `isV1Blocked`, `isBlacklisted`, `isV1Frontend`.
* Contract identity: `CONTRACT_ID()` for downstream checks by the V2 when setting the new Validator.
* V2 integration, the controller calls `validator.validate(...)` before moving balances. Example from `src/controllers/GnosisController.sol`:

https://github.com/monerium/smart-contracts/blob/29464dd77148ade5d0fba829e2c8efd7c7fa3ac3/src/controllers/GnosisControllerToken.sol#L80-L103


* `src/Token.sol` setter (already present), used to switch to the new validator:

  https://github.com/monerium/smart-contracts/blob/29464dd77148ade5d0fba829e2c8efd7c7fa3ac3/src/Token.sol#L110-L114

## How to Test

### Install

```bash
yarn install
forge install
```

### Unit tests

```bash
forge test --match-contract '^ValidatorTest'
```

### Coverage

```bash
forge coverage --match-contract ^ValidatorTest
```

Sample output:

```
Ran 10 tests for test/Validator.t.sol:ValidatorTest
[PASS] testAdminRole() (gas: 24953)
[PASS] testBlacklistedRole() (gas: 24995)
[PASS] testBlockedRole() (gas: 25018)
[PASS] testContractId() (gas: 5859)
[PASS] testFrontendRole() (gas: 25060)
[PASS] testIsAdminAccount() (gas: 20778)
[PASS] testIsBlacklisted() (gas: 14912)
[PASS] testIsV1Blocked() (gas: 14871)
[PASS] testIsV1Frontend() (gas: 14804)
[PASS] testValidateTransfer() (gas: 53251)
Suite result: ok. 10 passed; 0 failed; 0 skipped; finished in 16.83ms (8.65ms CPU time)

Ran 1 test suite in 182.94ms (16.83ms CPU time): 10 tests passed, 0 failed, 0 skipped (10 total tests)

╭---------------------------+-----------------+-----------------+---------------+-----------------╮
| File                      | % Lines         | % Statements    | % Branches    | % Funcs         |
+=================================================================================================+
| src/Validator.sol         | 100.00% (39/39) | 100.00% (30/30) | 100.00% (3/3) | 100.00% (15/15) |
╰---------------------------+-----------------+-----------------+---------------+-----------------╯
```

We have 100% coverage for the validator.

## Deployment plan (Gnosis first)

1. Deploy `Validator`.
2. Grant admin roles: `setAdmin(<monerium admins>)`
3. Set EURe V1 frontend `setV1Frontend(0xcB444e90D8198415266c6a2724b7900fb12FC56E)`
4. Block balancer V3 Vault `setV1Blocked(0xbA1333333333a1BA1108E8412f11850A5C319bA9)`
5. Point V2 to the new validator: `Token.setValidator(<validatorAddress>)`
4. Verify by attempting:
   * A V1-originating transfer to the Balancer V3 Vault, expect revert.
   * A normal V1 transfer to a non-blocked address, expect success.
   * A V2-originating transfer to the Balancer V3 Vault, expect sucess.
   * A normal V2 transfer to a non-blocked address, expect success.
